### PR TITLE
docs(readme): fix incorrect git clone link

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ A minimal, ready-to-use template for creating Hytale plugins with modern build t
 ### 1. Clone or Download
 
 ```bash
-git clone https://github.com/yourusername/hytale-plugin-template.git
+git clone https://github.com/realBritakee/hytale-template-plugin.git
 cd hytale-plugin-template
 ```
 


### PR DESCRIPTION
This pull request updates the project documentation to reference the correct GitHub repository for cloning the template.

Documentation update:

* Updated the `README.md` to use the correct repository URL in the clone instructions, ensuring users clone from `realBritakee/hytale-template-plugin` instead of the placeholder URL.